### PR TITLE
图片输入支持引用带有图片的消息;支持多图输入;

### DIFF
--- a/nonebot_plugin_aitalk/__init__.py
+++ b/nonebot_plugin_aitalk/__init__.py
@@ -410,7 +410,8 @@ async def _(event: GroupMessageEvent | PrivateMessageEvent, bot: Bot):
             model_name_val = model_conf_item.model_name
             send_thinking_enabled = model_conf_item.send_thinking
             if model_conf_item.image_input:  # 如果模型支持图片输入
-                images_base64 = await get_images(event)  # 从消息中提取图片
+                # --- 修改调用 get_images 的地方，传入 bot ---
+                images_base64 = await get_images(event, bot)
             break
 
     if not selected_model_config:


### PR DESCRIPTION
另外：
1、
在模型负载率高时可能报错503，未做处理，可以尝试导入openai库做一些简单的用户提示“模型负载高，本次请求未成功”。
2、README.md文件选填项配置表格中未包含aitalk_tts_enabled和aitalk_tts_enabled


05-07 21:36:49 [ERROR] nonebot | Running Matcher(type='message', module=nonebot_plugin_aitalk, lineno=328) failed.
Traceback (most recent call last):
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot_plugin_aitalk/__init__.py", line 613, in
 _
    reply_content_str, thinking_content_str = await gen(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot_plugin_aitalk/api.py", line 27, in gen
    completion = await client.chat.completions.create(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py
", line 1927, in create
    return await self._post(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1862, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1556, in request
    return await self._request(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1642, in _request
    return await self._retry_request(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1689, in _retry_re
quest
    return await self._request(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1642, in _request
    return await self._retry_request(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1689, in _retry_re
quest
    return await self._request(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1657, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.InternalServerError: Error code: 503 - [{'error': {'code': 503, 'message': 'The model is overloaded. Please try a
gain later.', 'status': 'UNAVAILABLE'}}]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 15, in <module>
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot/__init__.py", line 337, in run
    get_driver().run(*args, **kwargs)
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot/drivers/fastapi.py", line 187, in run
    uvicorn.run(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/uvicorn/main.py", line 579, in run
    server.run()
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/uvicorn/server.py", line 66, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot/utils.py", line 254, in run_coro_with_shield
    return await coro
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot/message.py", line 506, in check_and_run_matcher
    await _run_matcher(
> File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot/message.py", line 458, in _run_matcher
    await matcher.run(bot, event, state, stack, dependency_cache)
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot/internal/matcher/matcher.py", line 926, in run
    await self.simple_run(bot, event, state, stack, dependency_cache)
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot/internal/matcher/matcher.py", line 863, in simple_run
    await handler(
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot/dependencies/__init__.py", line 113, in __call__
    return await cast(Callable[..., Awaitable[R]], self.call)(**values)
  File "/www/program/nonebot2/lolbot/.venv/lib/python3.11/site-packages/nonebot_plugin_aitalk/__init__.py", line 666, in _
    logger.error(
KeyError: "'error'"