### PR TITLE
fix: 表情包本地文件改用 bytes 传输以兼容异地部署的 OneBot 实现

### DIFF
--- a/nonebot_plugin_aitalk/__init__.py
+++ b/nonebot_plugin_aitalk/__init__.py
@@ -306,9 +306,17 @@ async def format_reply(
             for meme_item in memes:
                 if meme_item["url"] == msg_dict.get("url"):
                     url = meme_item["url"]
-                    if not url.startswith(("http://", "https://")):
-                        url = f"file:///{os.path.abspath(url.replace(os.sep, '/'))}"  # 修正路径处理
-                    return MessageSegment.image(url)
+                    if url.startswith(("http://", "https://")):
+                        return MessageSegment.image(url)
+                    # 本地文件读取为 bytes，避免远程 OneBot 实现（如异地部署的 NapCat）无法访问本地路径
+                    local_path = Path(url)
+                    if not local_path.is_absolute():
+                        local_path = Path(os.path.abspath(url))
+                    try:
+                        return MessageSegment.image(local_path.read_bytes())
+                    except OSError as e:
+                        logger.warning(f"读取本地表情包失败: {local_path} ({e})")
+                        return MessageSegment.text(f"[表情包加载失败]")
             return MessageSegment.text("[未知表情包 URL]")
         elif msg_type == "tts":
             # 语音合成


### PR DESCRIPTION
## 问题

`nonebot_plugin_aitalk/__init__.py` 中处理 `meme` 消息段时，对本地路径表情包会拼出 `file:///绝对路径` URI 再交给 `MessageSegment.image()`：

```python
if not url.startswith(("http://", "https://")):
    url = f"file:///{os.path.abspath(url.replace(os.sep, '/'))}"
return MessageSegment.image(url)
```

NoneBot 的 OneBot v11 适配器并不会读取这个文件，而是直接把 `file://` URI 透传给 OneBot 实现（NapCat / Lagrange / go-cqhttp 等）去打开。**当 OneBot 实现与 NoneBot 异地部署时**（比如 NapCat 跑在另一台机器 / 另一个容器 / WSL），它在自己的文件系统里找不到这个路径，必然报错，表情包发不出去。

## 修复

本地路径直接用 `Path.read_bytes()` 读成 `bytes`，传给 `MessageSegment.image()`。OneBot v11 适配器对 `bytes` 入参会自动转成 `base64://...` 嵌入消息体，OneBot 实现完全不需要访问 NoneBot 主机上的文件。

- `http(s)://` URL 走原分支，行为完全不变；
- 新增对读文件失败的兜底（返回 `[表情包加载失败]` 文本段 + warning 日志），避免一张表情包损坏 / 路径配错就让整条 AI 回复构造失败；
- 不引入新依赖。

## 影响面

- 同机部署：原本 `file://` 也能跑，改成 base64 后体积略增，但 OneBot 实现实际处理路径反而更稳（不会因权限 / 工作目录差异翻车）。
- 异地部署：从"必坏"变成"正常工作"。
- 远程 URL：零影响。