### PR TITLE
🐛 修复 @机器人 时抢占其他插件命令的问题

### DIFF
--- a/nonebot_plugin_aitalk/__init__.py
+++ b/nonebot_plugin_aitalk/__init__.py
@@ -769,12 +769,15 @@ async def active_reply_context_rule(
 
 
 # --- Matcher 定义 ---
-# 1. 处理 @机器人 或特定命令前缀的群聊消息 (优先级最高)
+# 1. 处理 @机器人 或特定命令前缀的群聊消息
+# 采用较大的 priority + block=False，让本插件作为"兜底"处理 @机器人 的消息：
+# 其他需要"@机器人 + 触发词"的插件（如 remake 等）可以先匹配；只有当
+# 它们都未拦截时，aitalk 才接管，避免抢占其他插件的命令。
 handler = on_message(
     rule=at_me_rule,
     permission=GROUP,
-    priority=10,
-    block=True,  # 匹配到则阻塞后续同优先级Matcher
+    priority=99,
+    block=False,
 )
 # 2. 处理私聊消息 (优先级与@机器人相同)
 handler_private = on_message(


### PR DESCRIPTION
## Summary

- 将 `@机器人` 消息处理器（`handler`）的 `priority` 由 `10` 改为 `99`，并将 `block` 由 `True` 改为 `False`
- 让本插件作为"兜底"处理 `@机器人` 的消息：其他需要"`@机器人` + 触发词"的插件（如 remake 等）可以先匹配；只有当它们都未拦截时，aitalk 才接管，避免被本插件误抢占

## 背景

当前实现中，`at_me_rule` 只检查 `event.to_me`（默认未配置 `aitalk_command_start` 时），并以 `priority=10, block=True` 注册。这导致所有 `@机器人` 的消息都会被本插件抢占并阻断后续优先级的 matcher，例如 remake 这类需要"`@机器人` + 关键词"才触发的插件无法正常运行。

将本插件的 `@机器人` 处理器放到较大的 priority 并取消阻塞，能让其它依赖 `@机器人` 触发的命令型插件优先匹配；它们都未匹配时本插件再接管，符合"聊天兜底"的语义。

## Test plan

- [ ] 同时启用 remake 类插件和本插件，`@机器人 remake`：remake 插件正常响应，aitalk 不抢占
- [ ] `@机器人 你好`：aitalk 正常作为兜底回复
- [ ] `/选择模型`、`/清空聊天记录`、`/ai对话` 等命令仍正常工作（它们使用 `on_command`，本身 priority 更低）
- [ ] 主动回复与上下文追问逻辑不受影响